### PR TITLE
fix(listbar): shortcut key should use more visible colors

### DIFF
--- a/widgets/toolbar.widget.js
+++ b/widgets/toolbar.widget.js
@@ -67,6 +67,9 @@ class myWidget extends baseWidget(EventEmitter) {
       keys: false,
       mouse: true,
       style: {
+        prefix: {
+          fg: 'yellow'
+        },
         bg: 'green',
         item: {
           bg: 'black',


### PR DESCRIPTION
# Summary
Makes use of better colors for the list bar

## Proposed Changes

  - Change grey color for listbar keys to yellow

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [x] Fixed issue #52 
