### PR TITLE
Use `/bin/sh` instead of `/bin/bash`

### DIFF
--- a/dockerRunScript.sh
+++ b/dockerRunScript.sh
@@ -4,4 +4,4 @@ currentFilePath=${BASH_SOURCE[0]}
 workingDir="$( dirname "$currentFilePath" )"
 containerId=`cat ${workingDir}/containerId.txt`
 
-docker exec -it "$containerId" /bin/bash
+docker exec -it "$containerId" /bin/sh


### PR DESCRIPTION
Bash is not available in all linux distributions so as described in #57, I propose to use `sh` instead.