### PR TITLE
feat(actionStatus): show status messages for actions

### DIFF
--- a/hooks/containers.hook.js
+++ b/hooks/containers.hook.js
@@ -78,7 +78,7 @@ class hook extends baseWidget(EventEmitter) {
         if (err) {
           return cb(err, {})
         }
-        return cb(null, {containers, images})
+        return cb(null, { containers, images })
       })
     })
   }
@@ -87,10 +87,12 @@ class hook extends baseWidget(EventEmitter) {
     if (this.widgetsRepo && this.widgetsRepo.has('containerList')) {
       const containerId = this.widgetsRepo.get('containerList').getSelectedContainer()
       if (containerId && containerId !== 0 && containerId !== false) {
+        const actionStatus = this.widgetsRepo.get('actionStatus')
+
         const title = 'Restarting container'
         let message = 'Restarting container...'
 
-        this.emit('loaderStart', {
+        actionStatus.emit('message', {
           title: title,
           message: message
         })
@@ -102,7 +104,7 @@ class hook extends baseWidget(EventEmitter) {
             message = 'Container restarted successfully'
           }
 
-          this.emit('loaderEnd', {
+          actionStatus.emit('message', {
             title: title,
             message: message
           })
@@ -115,10 +117,12 @@ class hook extends baseWidget(EventEmitter) {
     if (this.widgetsRepo && this.widgetsRepo.has('containerList')) {
       const containerId = this.widgetsRepo.get('containerList').getSelectedContainer()
       if (containerId && containerId !== 0 && containerId !== false) {
+        const actionStatus = this.widgetsRepo.get('actionStatus')
+
         const title = 'Stop container'
         let message = 'Stopping container...'
 
-        this.emit('loaderStart', {
+        actionStatus.emit('message', {
           title: title,
           message: message
         })
@@ -130,7 +134,7 @@ class hook extends baseWidget(EventEmitter) {
             message = 'Container stopped successfully'
           }
 
-          this.emit('loaderEnd', {
+          actionStatus.emit('message', {
             title: title,
             message: message
           })

--- a/widgets/actionStatus.widget.js
+++ b/widgets/actionStatus.widget.js
@@ -1,8 +1,10 @@
 'use strict'
+
+const EventEmitter = require('events')
 const baseWidget = require('../src/baseWidget')
 
-class myWidget extends baseWidget() {
-  constructor ({blessed = {}, contrib = {}, screen = {}, grid = {}}) {
+class myWidget extends baseWidget(EventEmitter) {
+  constructor ({ blessed = {}, contrib = {}, screen = {}, grid = {} }) {
     super()
     this.blessed = blessed
     this.contrib = contrib
@@ -14,22 +16,7 @@ class myWidget extends baseWidget() {
   }
 
   init () {
-    if (!this.widgetsRepo.has('containers')) {
-      return null
-    }
-
-    this.widget.on('keypress', (ch, key) => {
-      if (key.name === 'escape') {
-        this.widget.destroy()
-      }
-    })
-
-    const dockerHook = this.widgetsRepo.get('containers')
-    dockerHook.on('loaderStart', (data) => {
-      return this.update(data)
-    })
-
-    dockerHook.on('loaderEnd', (data) => {
+    this.on('message', (data) => {
       return this.update(data)
     })
   }

--- a/widgets/actionsMenu.widget.js
+++ b/widgets/actionsMenu.widget.js
@@ -3,7 +3,7 @@
 const baseWidget = require('../src/baseWidget')
 
 class myWidget extends baseWidget() {
-  constructor ({blessed = {}, contrib = {}, screen = {}, grid = {}}) {
+  constructor ({ blessed = {}, contrib = {}, screen = {}, grid = {} }) {
     super()
     this.blessed = blessed
     this.contrib = contrib
@@ -26,29 +26,54 @@ class myWidget extends baseWidget() {
   }
 
   stopAllContainers () {
+    const actionStatus = this.widgetsRepo.get('actionStatus')
+    const data = {
+      title: 'Stopping all containers',
+      message: 'Stopping all containers...'
+    }
+
+    actionStatus.emit('message', data)
     this.utilsRepo.get('docker').stopAllContainers((res) => {
-      // @TODO not doing anything yet with the result
+      actionStatus.emit('message', Object.assign(data, { message: 'All containers stopped successfully' }))
     })
   }
 
   removeAllContainers () {
+    const actionStatus = this.widgetsRepo.get('actionStatus')
+    const data = {
+      title: 'Removing all containers',
+      message: 'Removing all containers...'
+    }
+
     this.utilsRepo.get('docker').removeAllContainers((res) => {
-      // @TODO not doing anything yet with the result
+      actionStatus.emit('message', Object.assign(data, { message: 'All containers removed successfully' }))
     })
   }
 
   removeAllImages () {
+    const actionStatus = this.widgetsRepo.get('actionStatus')
+    const data = {
+      title: 'Removing all images',
+      message: 'Removing all images...'
+    }
+
     this.utilsRepo.get('docker').removeAllImages((res) => {
-      // @TODO not doing anything yet with the results
+      actionStatus.emit('message', Object.assign(data, { message: 'All images removed successfully' }))
     })
   }
 
   deleteSelectedContainer () {
+    const actionStatus = this.widgetsRepo.get('actionStatus')
+    const data = {
+      title: 'Removing selected container',
+      message: 'Removing selected container...'
+    }
+
     if (this.widgetsRepo && this.widgetsRepo.has('containerList')) {
       const containerId = this.widgetsRepo.get('containerList').getSelectedContainer()
       if (containerId && containerId !== 0 && containerId !== false) {
         this.utilsRepo.get('docker').removeContainer(containerId, () => {
-          // TODO: emit an event for a refreshed list of containers and images
+          actionStatus.emit('message', Object.assign(data, { message: `Container removed successfully: ${containerId}` }))
         })
       }
     }


### PR DESCRIPTION
# Summary
The `actionStatus` widget now properly shows status messages made by different widgets

## Proposed Changes
  - Refactor event emitter usage for actionStatus
  - Update status messages for stop/restart container and menu actions

