### PR TITLE
feat(containerlist): refreshing maintains selected item focus

### DIFF
--- a/src/widgetsTemplates/list.widget.template.js
+++ b/src/widgetsTemplates/list.widget.template.js
@@ -25,7 +25,7 @@ class myWidget extends baseWidget(EventEmitter) {
 
     this.widget.on('select', (item, idx) => {
       // extract the first column out of the table row which is the item id
-      const itemId = item.getContent().toString().trim().split(' ').shift()
+      const itemId = this.getItemId(item)
       if (!itemId) {
         return null
       }
@@ -98,12 +98,21 @@ class myWidget extends baseWidget(EventEmitter) {
   refreshList () {
     this.getListItems((err, data) => {
       if (!err) {
+        const selectedIndex = this.widget.selected
         this.update(this.formatList(data))
-        this.widget.select(1)
+        this.widget.select(selectedIndex)
         this.focus()
         this.screen.render()
       }
     })
+  }
+
+  getItemId (item) {
+    if (!item) {
+      return null
+    }
+
+    return item.getContent().toString().trim().split(' ').shift()
   }
 
   getLabel () {

--- a/widgets/containers/containerList.widget.js
+++ b/widgets/containers/containerList.widget.js
@@ -6,6 +6,11 @@ const figures = require('figures')
 const ListWidget = require('../../src/widgetsTemplates/list.widget.template')
 
 class myWidget extends ListWidget {
+  constructor ({blessed = {}, contrib = {}, screen = {}, grid = {}}) {
+    super({blessed, contrib, screen, grid})
+    this.containersList = {}
+  }
+
   getLabel () {
     return 'Containers'
   }
@@ -23,19 +28,27 @@ class myWidget extends ListWidget {
   }
 
   formatList (containers) {
-    const list = []
-
     if (containers) {
       containers.forEach((container) => {
-        list.push([container.Id.substring(0, 5), container.Names[0].substring(0, 20), container.Image.substring(0, 19), container.Command.substring(0, 30), container.State, container.Status])
+        this.containersList[container.Id] = [
+          container.Id.substring(0, 5),
+          container.Names[0].substring(0, 40),
+          container.Image.substring(0, 35),
+          container.Command.substring(0, 30),
+          container.State,
+          container.Status
+        ]
       })
     }
 
-    list.sort(this.sortContainers)
+    let list = []
+    list = Object.keys(this.containersList).map((key) => {
+      let container = []
 
-    list.map((container) => {
+      container = this.containersList[key]
       container[4] = this.formatContainerState(container[4])
       container[5] = this.formatContainerStatus(container[5])
+
       return container
     })
 


### PR DESCRIPTION
# Summary
Refreshing the containers list maintains selected item focus

## Proposed Changes
  - Remove default sort by container status so it doesn't tamper with selected index
  - We keep an internal state to append item instead of recreating the list in indeterministic order

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [ ] Fixed issue #
- [ ] I added a picture of a cute animal cause it's fun
