### PR TITLE
Add badge to display install size

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![npm module downloads](http://img.shields.io/npm/dt/dockly.svg)](https://www.npmjs.org/package/dockly)
 [![Dependency Status](https://david-dm.org/lirantal/dockly.svg)](https://david-dm.org/lirantal/dockly)
 [![Codefresh build status]( https://g.codefresh.io/api/badges/build?repoOwner=lirantal&repoName=dockly&branch=master&pipelineName=dockly&accountName=lirantal&type=cf-1)]( https://g.codefresh.io/repositories/lirantal/dockly/builds?filter=trigger:build;branch:master;service:58127ed36b0e230100f421f6~dockly)
+[![Install Size](https://packagephobia.now.sh/badge?p=dockly)](https://packagephobia.now.sh/result?p=dockly)
 [![Security Responsible Disclosure](https://img.shields.io/badge/Security-Responsible%20Disclosure-yellow.svg)](https://github.com/nodejs/security-wg/blob/master/processes/responsible_disclosure_template.md
 )
 


### PR DESCRIPTION
# Summary

This adds a badge to the readme that displays the npm install size.

## Proposed Changes

  - add a badge to the readme

## Checklist

- [ ] I added tests
- [x] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [ ] Fixed issue #
- [ ] I added a picture of a cute animal cause it's fun
