### PR TITLE
refactor(shell.hook): auto-detect terminal apps

### DIFF
--- a/hooks/shell.hook.js
+++ b/hooks/shell.hook.js
@@ -1,9 +1,8 @@
 'use strict'
-
 const path = require('path')
-const opn = require('opn')
 const fs = require('fs')
 const baseWidget = require('../src/baseWidget')
+const TerminalLauncher = require('../lib/TerminalLauncher')
 
 class hook extends baseWidget() {
   init () {
@@ -26,18 +25,18 @@ class hook extends baseWidget() {
       let containerIdFile = path.join(__dirname, '/../containerId.txt')
       fs.writeFile(containerIdFile, containerId, 'utf8', (err) => {
         if (!err) {
-          return opn(`${__dirname}/../dockerRunScript.sh`)
-            .catch((err) => {
-              const actionStatus = this.widgetsRepo.get('actionStatus')
+          TerminalLauncher.launchTerminal().catch((err) => {
+            console.log(err)
+            const actionStatus = this.widgetsRepo.get('actionStatus')
 
-              const title = 'Shell login to container'
-              const message = 'Failed opening shell login for container: ' + containerId + ' - ' + err
+            const title = 'Shell login to container'
+            const message = 'Failed opening shell login for container: ' + containerId + ' - ' + err
 
-              actionStatus.emit('message', {
-                title: title,
-                message: message
-              })
+            actionStatus.emit('message', {
+              title: title,
+              message: message
             })
+          })
         }
       })
     }

--- a/lib/TerminalLauncher.js
+++ b/lib/TerminalLauncher.js
@@ -1,0 +1,39 @@
+'use strict'
+const opn = require('opn')
+
+const dockerRunScriptPath = `${__dirname}/../dockerRunScript.sh`
+const terminalAppsInfo = [
+  // MacOS variations of terminal apps
+  'Hyper',
+  'iTerm',
+  'terminal.app',
+  // Linux variations of terminal apps
+  ['x-terminal-emulator', '-e'],
+  ['gnome-terminal', '-e'],
+  ['konsole', '-e'],
+  ['xterm', '-e'],
+  ['urxvt', '-e'],
+  [process.env.COLORTERM, '-e'],
+  [process.env.XTERM, '-e']
+]
+
+class TerminalLauncher {
+  static getTerminals () {
+    const terminalApps = terminalAppsInfo.map((appInfo) => {
+      return () => opn(dockerRunScriptPath, { app: appInfo })
+    })
+
+    terminalApps.push(() => opn(dockerRunScriptPath))
+    return terminalApps
+  }
+
+  static launchTerminal () {
+    const shellLauncher = TerminalLauncher.getTerminals().reduce((promise, nextPromise) => {
+      return promise.catch(nextPromise)
+    }, Promise.reject()) /* eslint prefer-promise-reject-errors: "off" */
+
+    return shellLauncher
+  }
+}
+
+module.exports = TerminalLauncher


### PR DESCRIPTION
Fixes #81, #76, #55 

# Summary
Refactors the shell execution so that it tries to auto-detect terminal apps on both MacOS and Linux and reverts back to opn app's last resort of auto-detecting internally.