### PR TITLE
feat(Dockerfile): support for ARM/ARM64 architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8-alpine
 
 LABEL maintainer="Liran Tal <liran.tal@gmail.com>"
 LABEL contributor="Eitan Schichmanter <eitan.sch@gmail.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:8
+FROM node:8
 
 LABEL maintainer="Liran Tal <liran.tal@gmail.com>"
 LABEL contributor="Eitan Schichmanter <eitan.sch@gmail.com>"


### PR DESCRIPTION
# Summary
The docker image, as it currently exists, does not support ARM systems (e.g. Raspberry Pi) which are resource-constrained and often run headless, accessed via ssh.  This change allows the image to be built on Raspberry Pi (tested on Raspberry Pi 3 B+/Docker version 18.09.0, build 4d60db4) and any other architecture supported by the official Node.js image.

![2019-01-13_12-14-13](https://user-images.githubusercontent.com/5969754/51088436-a45c7280-172d-11e9-839c-ba31ec45ef09.png)
![2019-01-13_12-16-33](https://user-images.githubusercontent.com/5969754/51088441-b63e1580-172d-11e9-85c7-a92afa05ffd6.png)


## Proposed Changes

  - Change base image from mhart/alpine-node:8 to official node:8 image

## Checklist

- [x ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [ ] Fixed issue #
- [ ] I added a picture of a cute animal cause it's fun
