### PR TITLE
Add functionality to clear the logbox of any previous logs on select

### DIFF
--- a/src/widgetsTemplates/list.widget.template.js
+++ b/src/widgetsTemplates/list.widget.template.js
@@ -29,6 +29,9 @@ class myWidget extends baseWidget(EventEmitter) {
         return null
       }
 
+      // clear log box of previous logs
+      this.clearItemLogs()
+
       // get logs for the items
       this.getItemLogs(itemId, (err, stream) => {
         if (err) {
@@ -133,6 +136,10 @@ class myWidget extends baseWidget(EventEmitter) {
 
   updateItemLogs (str) {
     throw new Error('method updateItemLogs not implemented')
+  }
+
+  clearItemLogs (str) {
+    throw new Error('method clearItemlogs not implemented')
   }
 
   filterList (data) {

--- a/src/widgetsTemplates/logs.widget.template.js
+++ b/src/widgetsTemplates/logs.widget.template.js
@@ -60,6 +60,10 @@ class myWidget extends baseWidget() {
   update (data) {
     return this.widget.add(data)
   }
+
+  clear () {
+    return this.widget.setContent()
+  }
 }
 
 module.exports = myWidget

--- a/widgets/containers/containerList.widget.js
+++ b/widgets/containers/containerList.widget.js
@@ -24,6 +24,10 @@ class myWidget extends ListWidget {
     return this.widgetsRepo.get('containerLogs').update(str)
   }
 
+  clearItemLogs () {
+    return this.widgetsRepo.get('containerLogs').clear()
+  }
+
   getListItems (cb) {
     this.utilsRepo.get('docker').listContainers(cb)
   }

--- a/widgets/services/servicesList.widget.js
+++ b/widgets/services/servicesList.widget.js
@@ -15,6 +15,10 @@ class myWidget extends ListWidget {
     return this.widgetsRepo.get('servicesLogs').update(str)
   }
 
+  clearItemLogs () {
+    return this.widgetsRepo.get('servicesLogs').clear()
+  }
+
   getListItems (cb) {
     this.utilsRepo.get('docker').listServices(cb)
   }


### PR DESCRIPTION
# Summary
added functionality to clear the log box of any previous logs on select

## Proposed Changes

  - add abstract function & function call to clear log box widget with `list.widget.template.js`

  - add `clearItemLogs()` function within `(servicesList|containerList).widget.js` to call log box `clear()` function

  - add `clear()` function within `logs.widget.template.js` so we have a clean way to clear the log box content

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [x] Fixed issue #88
- [x] [I added a picture of a cute animal cause it's fun](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ2_-wNn7wxwnYT3KvwilbMz_rZia0iK0e6-xAHTiU65iro7sftKA)
