### PR TITLE
Seamlessly integrate docker interactive shell with dockly

### DIFF
--- a/dockerRunScript.sh
+++ b/dockerRunScript.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-currentFilePath=${BASH_SOURCE[0]}
-workingDir="$( dirname "$currentFilePath" )"
-containerId=`cat ${workingDir}/containerId.txt`
-
-docker exec -it "$containerId" /bin/sh

--- a/hooks/shell.hook.js
+++ b/hooks/shell.hook.js
@@ -33,7 +33,7 @@ class hook extends baseWidget() {
         try {
           console.clear()
 
-          cp.execSync(`docker exec -it "${containerId}" /bin/sh`, {
+          cp.execFileSync('docker', ['exec', '-it', containerId, '/bin/sh'], {
             'stdio': 'inherit'
           })
 

--- a/hooks/shell.hook.js
+++ b/hooks/shell.hook.js
@@ -1,8 +1,8 @@
-'use strict'
-const path = require('path')
-const fs = require('fs')
-const baseWidget = require('../src/baseWidget')
-const TerminalLauncher = require('opn-shell')
+'use strict';
+
+const baseWidget = require('../src/baseWidget');
+const cp = require('child_process');
+const console = require('console');
 
 class hook extends baseWidget() {
   init () {
@@ -20,28 +20,42 @@ class hook extends baseWidget() {
   }
 
   openShell () {
-    const dockerRunScriptPath = `${__dirname}/../dockerRunScript.sh`
-    let containerId = this.widgetsRepo.get('containerList').getSelectedContainer()
+    const containerList = this.widgetsRepo.get('containerList')
+    const containerId = containerList.getSelectedContainer()
 
     if (containerId) {
-      let containerIdFile = path.join(__dirname, '/../containerId.txt')
-      fs.writeFile(containerIdFile, containerId, 'utf8', (err) => {
-        if (!err) {
-          TerminalLauncher.launchTerminal({ path: dockerRunScriptPath }).catch((err) => {
-            console.log(err)
-            const actionStatus = this.widgetsRepo.get('actionStatus')
+      this.utilsRepo.get('docker').getContainer(containerId, (_, container) => {
+        if (!container.State.Running) {
+          this.emitActionStatus('Oops!', 'Cannot attach interactive shell - Container is not running.')
 
-            const title = 'Shell login to container'
-            const message = 'Failed opening shell login for container: ' + containerId + ' - ' + err
+          return
+        }
 
-            actionStatus.emit('message', {
-              title: title,
-              message: message
-            })
+        try {
+          console.clear()
+          cp.execSync(`docker exec -it "${containerId}" /bin/sh`, {
+            'stdio': 'inherit'
           })
+
+          this.emitActionStatus('Ok', 'Exitted shell.')
+
+        } catch (error) {
+          this.emitActionStatus('Error', error)
+        } finally {
+          console.clear()
+          // Force realloc buffers because tracked history is not valid anymore
+          containerList.screen.realloc()
         }
       })
     }
+  }
+
+  emitActionStatus (title, message) {
+    const actionStatus = this.widgetsRepo.get('actionStatus')
+    actionStatus.emit('message', {
+      message,
+      title
+    })
   }
 }
 

--- a/hooks/shell.hook.js
+++ b/hooks/shell.hook.js
@@ -1,8 +1,8 @@
-'use strict';
+'use strict'
 
-const baseWidget = require('../src/baseWidget');
-const cp = require('child_process');
-const console = require('console');
+const baseWidget = require('../src/baseWidget')
+const cp = require('child_process')
+const console = require('console')
 
 class hook extends baseWidget() {
   init () {
@@ -27,18 +27,17 @@ class hook extends baseWidget() {
       this.utilsRepo.get('docker').getContainer(containerId, (_, container) => {
         if (!container.State.Running) {
           this.emitActionStatus('Oops!', 'Cannot attach interactive shell - Container is not running.')
-
           return
         }
 
         try {
           console.clear()
+
           cp.execSync(`docker exec -it "${containerId}" /bin/sh`, {
             'stdio': 'inherit'
           })
 
           this.emitActionStatus('Ok', 'Exitted shell.')
-
         } catch (error) {
           this.emitActionStatus('Error', error)
         } finally {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "dockerode": "2.5.8",
     "figures": "^2.0.0",
     "glob": "^7.1.2",
-    "opn-shell": "^1.0.1",
     "semver": "5.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

![integrated-shell](https://user-images.githubusercontent.com/12202969/52742747-bead9880-2fd8-11e9-84b0-55d339f4c7e8.gif)

It basically freezes blessedjs (because of execSync), clears console and executes docker command. After interactive console is exitted, console is cleared and blessedjs is forced to redraw whole screen - blessedjs keeps track of changes but my _stdio magic_ causes it to get out of sync. Standard streams are seamlessly inheritted, so it should theoretically work in any terminal and OS - even through SSH. Application is never closed, so application state is untouched. Also, there is no need for separate *.sh script (or Windows equivalent)

It was tested on Windows 10 and partially on Ubuntu (no docker installed, just mounted docker socket so shell couldn't be attached)

## Proposed Changes

  - Makes "open shell" feature cross-platform, user-friendly and works with standard stdio, so it should work with any terminal emulator or headless systems (e.g. through ssh).

## Proposed Test Cases (manual)

1. Attach shell to stopped container
    - does not attach
    - displays appropriate status
2. Attach shell to running container
    - does attach
    - screen is cleared
    - user is able to execute commands and see results
3. Exit from attached shell - 'exit' command
    - dockly GUI is correctly re-drawn
    - displays appropriate status
4. Exit from attached shell - ctrl + Z
    - dockly GUI is correctly re-drawn
    - displays appropriate status


## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [x] This PR introduces a breaking change
- [x] Fixed issue #83 
- [x] I added a ~~picture~~ [video of a cute animal cause it's fun](https://imgur.com/vyIqXeF)
