### PR TITLE
Add 'docker' to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM node:8-alpine
 LABEL maintainer="Liran Tal <liran.tal@gmail.com>"
 LABEL contributor="Eitan Schichmanter <eitan.sch@gmail.com>"
 
+RUN apk add docker && rm -rf /var/apk/cache/*
+
 COPY . /app
 WORKDIR /app
 ENV NODE_ENV production

--- a/hooks/shell.hook.js
+++ b/hooks/shell.hook.js
@@ -37,7 +37,7 @@ class hook extends baseWidget() {
             'stdio': 'inherit'
           })
 
-          this.emitActionStatus('Ok', 'Exitted shell.')
+          this.emitActionStatus('Ok', 'Exited shell.')
         } catch (error) {
           this.emitActionStatus('Error', error)
         } finally {


### PR DESCRIPTION
Fixes #102

# Summary

Installing docker fixes the issue. Downside is that it increases image size from 193 to 380 MB, but I think it's a sacrifice worth making for regaining functionality.
Another minor issue is that, at least for me, exec'ed shell does not show the cursor. Didn't look into that long, `stty echo` did not help. Any thoughts?

## Checklist

- [x] Fixed issue #102 
