### PR TITLE
fix(shell): disable mouse-on-shell

### DIFF
--- a/dockerRunScript.sh
+++ b/dockerRunScript.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# disable mouse as input source
+printf '\e[?1000l'
+
+docker exec -it "$1" /bin/sh -c "[ -e /bin/bash ] && /bin/bash || /bin/sh"
+
+# enable mouse as input source for dockly
+printf '\e[?1000h'

--- a/hooks/shell.hook.js
+++ b/hooks/shell.hook.js
@@ -3,6 +3,7 @@
 const baseWidget = require('../src/baseWidget')
 const cp = require('child_process')
 const console = require('console')
+const os = require('os')
 
 class hook extends baseWidget() {
   init () {
@@ -33,9 +34,15 @@ class hook extends baseWidget() {
         try {
           console.clear()
 
-          cp.execFileSync('docker', ['exec', '-it', containerId, '/bin/sh', '-c', '[ -e /bin/bash ] && /bin/bash || /bin/sh'], {
-            'stdio': 'inherit'
-          })
+          if (os.platform() === 'win32') {
+            cp.execFileSync('docker', ['exec', '-it', containerId, '/bin/sh', '-c', '[ -e /bin/bash ] && /bin/bash || /bin/sh'], {
+              'stdio': 'inherit'
+            })
+          } else {
+            cp.execFileSync(`${__dirname}/../dockerRunScript.sh`, [containerId], {
+              'stdio': 'inherit'
+            })
+          }
 
           this.emitActionStatus('Ok', 'Exited shell.')
         } catch (error) {


### PR DESCRIPTION
# Summary
Fixes https://github.com/lirantal/dockly/issues/109 by disabling the mouse on the shell being opened and restores it again.

## Proposed Changes

  - If OS is win32 leave as is
  - Otherwise, run script which disables the mouse on the shell, runs the docker shell command and restores mouse again
