### PR TITLE
feat: Change refresh key to space bar

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach",
+            "port": 9222,
+            "skipFiles": [
+                "<node_internals>/**"
+            ]
+        }
+    ]
+}

--- a/hooks/containers.hook.js
+++ b/hooks/containers.hook.js
@@ -25,7 +25,7 @@ class hook extends baseWidget(EventEmitter) {
     const toolbar = this.widgetsRepo.get('toolbar')
     toolbar.on('key', (keyString) => {
       // on refresh keypress, update all containers and images information
-      if (keyString === '=') {
+      if (keyString === 'space') { // refresh key space
         this.getFreshData((err, data) => {
           if (err) {
             data = {}

--- a/hooks/services.hook.js
+++ b/hooks/services.hook.js
@@ -24,7 +24,7 @@ class hook extends baseWidget(EventEmitter) {
     const toolbar = this.widgetsRepo.get('toolbar')
     toolbar.on('key', (keyString) => {
       // on refresh keypress, update all services and images information
-      if (keyString === '=') {
+      if (keyString === 'space') { // refresh key
         this.getFreshData((err, data) => {
           if (err) {
             data = {}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "standard && yarn run lint:lockfile",
     "lint:fix": "standard --fix",
     "lint:lockfile": "lockfile-lint --path yarn.lock --type yarn --validate-https --allowed-hosts npm yarn",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "debug": "node --inspect=0.0.0.0:9222 ./index.js "
   },
   "files": [
     "hooks",

--- a/src/widgetsTemplates/help.widget.template.js
+++ b/src/widgetsTemplates/help.widget.template.js
@@ -106,19 +106,20 @@ class myWidget extends baseWidget() {
     
     Available key commands:
 
-    ▸ h: Show/hide this window
-    ▸ =: Refresh the current view
-    ▸ /: Search the containers list view
-    ▸ i: Display information dialog about the selected container or service
-    ▸ ⏎: Show the logs of the current container or service
-    ▸ v: Toggle between Containers and Services view
-    ▸ q: Quit dockly
+    ▸ h:       Show/hide this window
+    ▸ <space>: Refresh the current view
+    ▸ /:       Search the containers list view
+    ▸ i:       Display information dialog about the selected container or service
+    ▸ ⏎:       Show the logs of the current container or service
+    ▸ v:       Toggle between Containers and Services view
+    ▸ q:       Quit dockly
     
     The following commands are only available in Container view:
-    ▸ l: Launch a /bin/bash session on the selected container
-    ▸ r: Restart the selected container
-    ▸ s: Stop the selected container
-    ▸ m: Show a menu with additional actions
+    
+    ▸ l:       Launch a /bin/bash session on the selected container
+    ▸ r:       Restart the selected container
+    ▸ s:       Stop the selected container
+    ▸ m:       Show a menu with additional actions
 
     Thanks for using dockly!
     `

--- a/src/widgetsTemplates/list.widget.template.js
+++ b/src/widgetsTemplates/list.widget.template.js
@@ -62,7 +62,7 @@ class myWidget extends baseWidget(EventEmitter) {
 
     const toolbar = this.widgetsRepo.get('toolbar')
     toolbar.on('key', (keyString) => {
-      if (keyString === '=') {
+      if (keyString === 'space') { // refresh key
         this.refreshList()
       }
     })

--- a/widgets/searchInput.widget.js
+++ b/widgets/searchInput.widget.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events')
 const baseWidget = require('../src/baseWidget')
 
-const ASCII_CHAR_START = 33
+const ASCII_CHAR_START = 32
 const ASCII_CHAR_END = 126
 
 class myWidget extends baseWidget(EventEmitter) {

--- a/widgets/toolbar.widget.js
+++ b/widgets/toolbar.widget.js
@@ -29,8 +29,8 @@ class myWidget extends baseWidget(EventEmitter) {
   createWidget () {
     const baseCommands = {
       'refresh': {
-        keys: ['='],
-        callback: () => { this.emit('key', '=') }
+        keys: ['space'], // refresh key
+        callback: () => { this.emit('key', 'space') } // key space
       },
       'info': {
         keys: ['i'],


### PR DESCRIPTION
# Summary
Since international keyboards do not all have '=' on an unshifted key and since you often would want to update the view easily the '=' key is not ideal

## Proposed Changes

  - I have changed the refresh key to the 'space' bar. 

  - Have added debug action to package.json for easy attach to node

  - Added launch.json in .vscode folder for easy debugging from Code

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [x] Fixed issue #135 
- [ ] I added a picture of a cute animal cause it's fun
