### PR TITLE
Updated dockerfile to node 12 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:12-alpine
 
 LABEL maintainer="Liran Tal <liran.tal@gmail.com>"
 LABEL contributor="Eitan Schichmanter <eitan.sch@gmail.com>"


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>

# Summary

Node 8 is now end of life as of 31st Dec 2019.

## Proposed Changes

Update docker image to use Node 12 which is LTS branch and supported until 30th Apr 2022
  -

  -

  -

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [ ] Fixed issue #
- [ ] I added a picture of a cute animal cause it's fun
