### PR TITLE
fix(containerlist): containerList used cached data

### DIFF
--- a/src/widgetsTemplates/list.widget.template.js
+++ b/src/widgetsTemplates/list.widget.template.js
@@ -151,6 +151,7 @@ class myWidget extends baseWidget(EventEmitter) {
   }
 
   update (data) {
+    this.widget.clearItems()
     return this.widget.setData(data)
   }
 }

--- a/widgets/containers/containerList.widget.js
+++ b/widgets/containers/containerList.widget.js
@@ -57,9 +57,10 @@ class myWidget extends ListWidget {
   }
 
   formatList (containers) {
+    const containerList = {}
     if (containers) {
       containers.forEach((container) => {
-        this.containersList[container.Id] = [
+        containerList[container.Id] = [
           container.Id.substring(0, 5),
           container.Names[0].substring(0, 40),
           container.Image.substring(0, 35),
@@ -71,10 +72,10 @@ class myWidget extends ListWidget {
     }
 
     let list = []
-    list = Object.keys(this.containersList).map((key) => {
+    list = Object.keys(containerList).map((key) => {
       let container = []
 
-      container = this.containersList[key]
+      container = containerList[key]
       container[4] = this.formatContainerState(container[4])
       container[5] = this.formatContainerStatus(container[5])
 
@@ -83,6 +84,7 @@ class myWidget extends ListWidget {
 
     list.unshift(['Id', 'Name', 'Image', 'Command', 'State', 'Status'])
     this.containersListData = list
+    this.containersList = containerList
 
     return list
   }


### PR DESCRIPTION
# Summary
Fixes #145 

## Proposed Changes
  - Container list used the cached containersList object on the widget instead of creating a new one and writing to it.

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [ ] Fixed issue #
- [ ] I added a picture of a cute animal cause it's fun
