### PR TITLE
feat(theme): support for light theme

### DIFF
--- a/src/baseWidget.js
+++ b/src/baseWidget.js
@@ -1,4 +1,5 @@
 'use strict'
+const getTheme = require('./themes/theme.selector')
 
 module.exports = (extendsClass = class {}) => {
   return class extends extendsClass {
@@ -16,6 +17,10 @@ module.exports = (extendsClass = class {}) => {
 
     focus () {
       this.widget.focus()
+    }
+
+    getWidgetStyle (customStyle = {}) {
+      return Object.assign({}, getTheme(), customStyle)
     }
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -29,6 +29,11 @@ function Cli () {
       name: 'containerFilters',
       type: String,
       description: 'Filter containers'
+    },
+    {
+      name: 'theme',
+      type: String,
+      description: 'Theme: light or dark (e.g. --theme light)'
     }
   ]
 }

--- a/src/themes/styles.js
+++ b/src/themes/styles.js
@@ -42,7 +42,7 @@ const lightStyle = {
     fg: 'black'
   },
   selected: {
-    bg: 'green',
+    bg: 'green'
   },
   cell: {
     fg: 'black',

--- a/src/themes/styles.js
+++ b/src/themes/styles.js
@@ -1,0 +1,58 @@
+const darkStyle = {
+  fg: 'white',
+  bg: 'black',
+  header: {
+    bg: 'black',
+    fg: 'blue',
+    bold: true
+  },
+  border: {
+    fg: 'white',
+    bg: 'black'
+  },
+  label: {
+    bg: 'black',
+    fg: 'white'
+  },
+  selected: {
+    bg: 'green'
+  },
+  cell: {
+    fg: 'magenta',
+    selected: {
+      bg: 'blue'
+    }
+  }
+}
+
+const lightStyle = {
+  fg: 'black',
+  bg: 'white',
+  header: {
+    bg: 'white',
+    fg: 'blue',
+    bold: true
+  },
+  border: {
+    fg: 'black',
+    bg: 'white'
+  },
+  label: {
+    bg: 'white',
+    fg: 'black'
+  },
+  selected: {
+    bg: 'green',
+  },
+  cell: {
+    fg: 'black',
+    selected: {
+      bg: 'blue'
+    }
+  }
+}
+
+module.exports = {
+  darkStyle,
+  lightStyle
+}

--- a/src/themes/theme.selector.js
+++ b/src/themes/theme.selector.js
@@ -1,4 +1,4 @@
-const {darkStyle, lightStyle} = require('./styles')
+const { darkStyle, lightStyle } = require('./styles')
 const cli = require('../cli')
 
 const themeStyleMap = {

--- a/src/themes/theme.selector.js
+++ b/src/themes/theme.selector.js
@@ -1,0 +1,19 @@
+const {darkStyle, lightStyle} = require('./styles')
+const cli = require('../cli')
+
+const themeStyleMap = {
+  light: lightStyle,
+  dark: darkStyle
+}
+
+const defaultTheme = 'dark'
+
+const isValidTheme = (theme) => themeStyleMap.hasOwnProperty(theme)
+
+module.exports = () => {
+  const cliOptions = cli.cliParse()
+  const theme = cliOptions.theme && isValidTheme(cliOptions.theme.toLowerCase())
+    ? cliOptions.theme.toLowerCase()
+    : defaultTheme
+  return themeStyleMap[theme]
+}

--- a/src/widgetsTemplates/help.widget.template.js
+++ b/src/widgetsTemplates/help.widget.template.js
@@ -69,11 +69,7 @@ class myWidget extends baseWidget() {
       scrollable: true,
       alwaysScroll: true,
       keys: true,
-      style: {
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle(),
       border: {
         type: 'line'
       },

--- a/src/widgetsTemplates/info.widget.template.js
+++ b/src/widgetsTemplates/info.widget.template.js
@@ -83,11 +83,7 @@ class myWidget extends baseWidget() {
       scrollable: true,
       alwaysScroll: true,
       keys: true,
-      style: {
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle(),
       border: {
         type: 'line'
       },

--- a/src/widgetsTemplates/list.widget.template.js
+++ b/src/widgetsTemplates/list.widget.template.js
@@ -86,18 +86,7 @@ class myWidget extends baseWidget(EventEmitter) {
       hover: {
         bg: 'blue'
       },
-      style: {
-        header: {
-          fg: 'blue',
-          bold: true
-        },
-        cell: {
-          fg: 'magenta',
-          selected: {
-            bg: 'blue'
-          }
-        }
-      },
+      style: this.getWidgetStyle(),
       align: 'center'
     })
   }

--- a/src/widgetsTemplates/logs.widget.template.js
+++ b/src/widgetsTemplates/logs.widget.template.js
@@ -52,17 +52,7 @@ class myWidget extends baseWidget() {
       alwaysScroll: true,
       keys: true,
       vi: true,
-      style: {
-        fg: 'default',
-        bg: 'default',
-        border: {
-          fg: 'default',
-          bg: 'default'
-        },
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle(),
       border: {
         type: 'line',
         fg: '#00ff00'

--- a/widgets/actionStatus.widget.js
+++ b/widgets/actionStatus.widget.js
@@ -31,11 +31,7 @@ class myWidget extends baseWidget(EventEmitter) {
       scrollable: true,
       alwaysScroll: true,
       tags: true,
-      style: {
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle(),
       border: {
         type: 'line'
       },

--- a/widgets/actionsMenu.widget.js
+++ b/widgets/actionsMenu.widget.js
@@ -125,11 +125,7 @@ class myWidget extends baseWidget() {
       alwaysScroll: true,
       keys: true,
       interactive: true,
-      style: {
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle(),
       border: {
         type: 'line'
       },

--- a/widgets/containers/containerStatus.widget.js
+++ b/widgets/containers/containerStatus.widget.js
@@ -34,7 +34,7 @@ class myWidget extends baseWidget() {
   getWidget () {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.contrib.gauge, {
       label: this.label,
-      style: this.getWidgetStyle({fg: 'blue'}),
+      style: this.getWidgetStyle({ fg: 'blue' }),
       border: {
         type: 'line',
         fg: '#00ff00'

--- a/widgets/containers/containerStatus.widget.js
+++ b/widgets/containers/containerStatus.widget.js
@@ -34,17 +34,7 @@ class myWidget extends baseWidget() {
   getWidget () {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.contrib.gauge, {
       label: this.label,
-      style: {
-        fg: 'blue',
-        bg: 'default',
-        border: {
-          fg: 'default',
-          bg: 'default'
-        },
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle({fg: 'blue'}),
       border: {
         type: 'line',
         fg: '#00ff00'

--- a/widgets/containers/containerUtilization.widget.js
+++ b/widgets/containers/containerUtilization.widget.js
@@ -27,17 +27,7 @@ class myWidget extends baseWidget() {
   getWidget () {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.contrib.bar, {
       label: this.label,
-      style: {
-        fg: 'blue',
-        bg: 'default',
-        border: {
-          fg: 'default',
-          bg: 'default'
-        },
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle({fg: 'blue'}),
       border: {
         type: 'line',
         fg: '#00ff00'
@@ -47,7 +37,8 @@ class myWidget extends baseWidget() {
       barWidth: 6,
       barSpacing: 15,
       xOffset: 3,
-      maxHeight: 15
+      maxHeight: 15,
+      labelColor: this.getWidgetStyle().fg
     })
   }
 

--- a/widgets/containers/containerUtilization.widget.js
+++ b/widgets/containers/containerUtilization.widget.js
@@ -27,7 +27,7 @@ class myWidget extends baseWidget() {
   getWidget () {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.contrib.bar, {
       label: this.label,
-      style: this.getWidgetStyle({fg: 'blue'}),
+      style: this.getWidgetStyle({ fg: 'blue' }),
       border: {
         type: 'line',
         fg: '#00ff00'

--- a/widgets/containers/containerVsImages.widget.js
+++ b/widgets/containers/containerVsImages.widget.js
@@ -30,17 +30,7 @@ class myWidget extends baseWidget() {
   getWidget () {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.contrib.bar, {
       label: this.label,
-      style: {
-        fg: 'blue',
-        bg: 'default',
-        border: {
-          fg: 'default',
-          bg: 'default'
-        },
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle(),
       border: {
         type: 'line',
         fg: '#00ff00'
@@ -51,7 +41,8 @@ class myWidget extends baseWidget() {
       barWidth: 6,
       barSpacing: 15,
       xOffset: 3,
-      maxHeight: 15
+      maxHeight: 15,
+      labelColor: this.getWidgetStyle().fg
     })
   }
 

--- a/widgets/searchInput.widget.js
+++ b/widgets/searchInput.widget.js
@@ -91,7 +91,7 @@ class myWidget extends baseWidget(EventEmitter) {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.blessed.textbox, {
       focused: false,
       border: 'line',
-      style: this.getWidgetStyle({bg: 'yellow', fg: 'black'}),
+      style: this.getWidgetStyle({ bg: 'yellow', fg: 'black' }),
       align: 'left',
       inputOnFocus: true,
       value: ''

--- a/widgets/searchInput.widget.js
+++ b/widgets/searchInput.widget.js
@@ -91,10 +91,7 @@ class myWidget extends baseWidget(EventEmitter) {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.blessed.textbox, {
       focused: false,
       border: 'line',
-      style: {
-        bg: 'yellow',
-        fg: 'black'
-      },
+      style: this.getWidgetStyle({bg: 'yellow', fg: 'black'}),
       align: 'left',
       inputOnFocus: true,
       value: ''

--- a/widgets/services/servicesStatus.widget.js
+++ b/widgets/services/servicesStatus.widget.js
@@ -30,17 +30,7 @@ class myWidget extends baseWidget() {
   getWidget () {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.contrib.gauge, {
       label: this.label,
-      style: {
-        fg: 'blue',
-        bg: 'default',
-        border: {
-          fg: 'default',
-          bg: 'default'
-        },
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle({fg: 'blue'}),
       border: {
         type: 'line',
         fg: '#00ff00'

--- a/widgets/services/servicesStatus.widget.js
+++ b/widgets/services/servicesStatus.widget.js
@@ -30,7 +30,7 @@ class myWidget extends baseWidget() {
   getWidget () {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.contrib.gauge, {
       label: this.label,
-      style: this.getWidgetStyle({fg: 'blue'}),
+      style: this.getWidgetStyle({ fg: 'blue' }),
       border: {
         type: 'line',
         fg: '#00ff00'

--- a/widgets/services/servicesVsImages.widget.js
+++ b/widgets/services/servicesVsImages.widget.js
@@ -30,7 +30,7 @@ class myWidget extends baseWidget() {
   getWidget () {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.contrib.bar, {
       label: this.label,
-      style: this.getWidgetStyle({fg: 'blue'}),
+      style: this.getWidgetStyle({ fg: 'blue' }),
       border: {
         type: 'line',
         fg: '#00ff00'

--- a/widgets/services/servicesVsImages.widget.js
+++ b/widgets/services/servicesVsImages.widget.js
@@ -30,17 +30,7 @@ class myWidget extends baseWidget() {
   getWidget () {
     return this.grid.gridObj.set(...this.grid.gridLayout, this.contrib.bar, {
       label: this.label,
-      style: {
-        fg: 'blue',
-        bg: 'default',
-        border: {
-          fg: 'default',
-          bg: 'default'
-        },
-        selected: {
-          bg: 'green'
-        }
-      },
+      style: this.getWidgetStyle({fg: 'blue'}),
       border: {
         type: 'line',
         fg: '#00ff00'


### PR DESCRIPTION
# Summary
Support light theme

## Proposed Changes

  - Add `--theme` argument with possible values `light` or `dark` (default)
  - Add documentation in `--help` command

Moved the basic styles to a separate file `styles.js` and add a theme selector function to select the style based on the `--theme` argument.
This solution gives the option to add other themes, not just dark and light. To do that, what is required is to add the relevant style in `styles.js` and then add the new style in `theme.selector.js`
```
const themeStyleMap = {
  light: lightStyle,
  dark: darkStyle
}
```

![image](https://user-images.githubusercontent.com/22660112/117150356-bf50c600-adc0-11eb-85a3-ec4e3f62a1d8.png)