### PR TITLE
Fix: dockly crash on service log expend

### DIFF
--- a/src/widgetsTemplates/logs.widget.template.js
+++ b/src/widgetsTemplates/logs.widget.template.js
@@ -37,7 +37,7 @@ class myWidget extends baseWidget() {
         this.widget.setContent(data)
         this.screen.render()
         // render the logs if in full view mode, or the containers if we drop to regular view
-        this.isExpanded ? this.widgetsRepo.get('containerLogs').focus() : this.widgetsRepo.get('containerList').focus()
+        this.isExpanded ? this.focus() : this.getList().focus()
       }
     })
   }
@@ -79,6 +79,10 @@ class myWidget extends baseWidget() {
 
   clear () {
     return this.widget.setContent()
+  }
+
+  getList() {
+    throw new Error('method getList not implemented')
   }
 }
 

--- a/widgets/containers/containerLogs.widget.js
+++ b/widgets/containers/containerLogs.widget.js
@@ -6,6 +6,10 @@ class myWidget extends LogWidget {
   getLabel () {
     return 'Container Logs'
   }
+
+  getList() {
+    return this.widgetsRepo.get('containerList')
+  }
 }
 
 module.exports = myWidget

--- a/widgets/services/servicesLogs.widget.js
+++ b/widgets/services/servicesLogs.widget.js
@@ -6,6 +6,10 @@ class myWidget extends LogWidget {
   getLabel () {
     return 'Service Logs'
   }
+
+  getList() {
+    return this.widgetsRepo.get('servicesList')
+  }
 }
 
 module.exports = myWidget


### PR DESCRIPTION
# Summary
Fix dockly crash when trying to expand services logs

## Proposed Changes

  - added a method to `logs.widget.template.js` to get the right log widget from the extended classes


## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [x] Fixed issue #156 
- [ ] I added a picture of a cute animal cause it's fun
