### PR TITLE
fix: tab not working in service tab

### DIFF
--- a/hooks/containers.hook.js
+++ b/hooks/containers.hook.js
@@ -48,6 +48,25 @@ class hook extends baseWidget(EventEmitter) {
         this.copyContainerIdToClipboard()
       }
     })
+
+    if (this.widgetsRepo.has('containerLogs') && this.widgetsRepo.has('containerList')) {
+      this.setupSwitchFocus()
+    }
+  }
+
+  setupSwitchFocus () {
+    const containerLogs = this.widgetsRepo.get('containerLogs')
+    const containerList = this.widgetsRepo.get('containerList')
+    const screen = containerLogs.screen
+    
+    this.toggleWidgetFocus = true
+
+    screen.on('keypress', (ch, key) => {
+      if (key && key.name === 'tab') {
+        this.toggleWidgetFocus ? containerLogs.focus() : containerList.focus()
+        this.toggleWidgetFocus = !this.toggleWidgetFocus
+      }
+    })
   }
 
   notifyOnContainerInfo () {

--- a/hooks/services.hook.js
+++ b/hooks/services.hook.js
@@ -38,6 +38,25 @@ class hook extends baseWidget(EventEmitter) {
         this.copyServiceIdToClipboard()
       }
     })
+
+    if (this.widgetsRepo.has('servicesLogs') && this.widgetsRepo.has('servicesList')) {
+      this.setupSwitchFocus()
+    }
+  }
+
+  setupSwitchFocus () {
+    const containerLogs = this.widgetsRepo.get('servicesLogs')
+    const containerList = this.widgetsRepo.get('servicesList')
+    const screen = containerLogs.screen
+
+    this.toggleWidgetFocus = true
+
+    screen.on('keypress', (ch, key) => {
+      if (key && key.name === 'tab') {
+        this.toggleWidgetFocus ? containerLogs.focus() : containerList.focus()
+        this.toggleWidgetFocus = !this.toggleWidgetFocus
+      }
+    })
   }
 
   notifyOnServiceInfo () {

--- a/src/screen.js
+++ b/src/screen.js
@@ -171,14 +171,6 @@ class screen {
   }
 
   registerEvents () {
-    this.screen.on('keypress', (ch, key) => {
-      if (key && key.name === 'tab') {
-        this.toggleWidgetFocus ? this.widgetsRepository.get('containerLogs').focus() : this.widgetsRepository.get('containerList').focus()
-        this.toggleWidgetFocus = !this.toggleWidgetFocus
-        this.screen.render()
-      }
-    })
-
     this.screen.on('element focus', (curr, old) => {
       if (old && old.border) {
         old.style.border.fg = 'default'


### PR DESCRIPTION
# Summary
fix `tab` not working in service view.

## Proposed Changes

  - Added event listener for the screen through hooks to update focus accordingly.

  - remove focus updates from the screen class. 


## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [X] Fixed issue #158 
- [ ] I added a picture of a cute animal cause it's fun
