### PR TITLE
fix: search not working in service view

### DIFF
--- a/src/widgetsTemplates/list.widget.template.js
+++ b/src/widgetsTemplates/list.widget.template.js
@@ -73,6 +73,10 @@ class myWidget extends baseWidget(EventEmitter) {
       searchInput.on('keypress', (data) => {
         this.filterList(data)
       })
+
+      searchInput.on('exitSearch', () => {
+        this.focus()
+      })
     }
   }
 

--- a/widgets/searchInput.widget.js
+++ b/widgets/searchInput.widget.js
@@ -63,7 +63,7 @@ class myWidget extends baseWidget(EventEmitter) {
         this.widget.clearValue()
         this.inputValue = []
         this.widget.destroy()
-        this.widgetsRepo.get('containerList').focus()
+        this.emit('exitSearch')
       } else {
         this.emit('keypress', this.captureText(key))
       }

--- a/widgets/services/servicesList.widget.js
+++ b/widgets/services/servicesList.widget.js
@@ -3,6 +3,11 @@
 const ListWidget = require('../../src/widgetsTemplates/list.widget.template')
 
 class myWidget extends ListWidget {
+  constructor ({ blessed = {}, contrib = {}, screen = {}, grid = {} }) {
+    super({ blessed, contrib, screen, grid })
+    this.servicesListData = []
+  }
+
   getLabel () {
     return 'Services'
   }
@@ -23,6 +28,30 @@ class myWidget extends ListWidget {
     this.utilsRepo.get('docker').listServices(cb)
   }
 
+  filterList (data) {
+    let filteredContainersList = this.servicesListData[0]
+    let serviceList = this.servicesListData.slice(1)
+    let filteredServices = []
+
+    if (data) {
+      filteredServices = serviceList.filter((service) => {
+        const serviceName = service[1]
+        const serviceImageName = service[2]
+
+        if ((serviceName.indexOf(data) !== -1) || (serviceImageName.indexOf(data) !== -1)) {
+          return true
+        }
+      })
+    }
+
+    if (filteredServices.length > 0) {
+      filteredServices.unshift(filteredContainersList)
+      this.update(filteredServices)
+    } else {
+      this.update(this.servicesListData)
+    }
+  }
+
   formatList (services) {
     const list = []
 
@@ -38,6 +67,8 @@ class myWidget extends ListWidget {
     }
 
     list.unshift(['Id', 'Name', 'Image', 'Replicas'])
+
+    this.servicesListData = list
 
     return list
   }

--- a/widgets/toolbar.widget.js
+++ b/widgets/toolbar.widget.js
@@ -47,6 +47,10 @@ class myWidget extends baseWidget(EventEmitter) {
       'copy id': {
         keys: ['c'],
         callback: () => { this.emit('key', 'c') }
+      },
+      'search': {
+        keys: ['/'],
+        callback: () => { this.emit('key', '/') }
       }
     }
 


### PR DESCRIPTION
# Summary
Added search in the service view.

## Proposed Changes

  - Added `filterList` in service view.

  - Added an event emitter in the search widget for when the search finished.

  - Added event listener in `list.widget.template.js` to focus on the list when the search finished.

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [x] Fixed issue #162 
- [ ] I added a picture of a cute animal cause it's fun
