### PR TITLE
ci: fix build_docs fails in forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
         node: ['14']
     name: Node ${{ matrix.node }} (${{ matrix.platform }})
     runs-on: ${{ matrix.platform }}
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2


### PR DESCRIPTION
# Summary
Added a check in the build_docs to make it activate only when pushing to master.

by doing that the job will not fail on forks.

## Proposed Changes

  - Added check to build_docs to work only when pushing to master

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [x] Fixed issue #160 
- [ ] I added a picture of a cute animal cause it's fun
