### PR TITLE
feat: copy id label changes depended on the view

### DIFF
--- a/widgets/toolbar.widget.js
+++ b/widgets/toolbar.widget.js
@@ -36,14 +36,15 @@ class myWidget extends baseWidget(EventEmitter) {
         keys: ['i'],
         callback: () => { this.emit('key', 'i') }
       },
-      'copy id': {
-        keys: ['c'],
-        callback: () => { this.emit('key', 'c') }
-      },
       'search': {
         keys: ['/'],
         callback: () => { this.emit('key', '/') }
       }
+    }
+
+    baseCommands[`copy ${this.mode.slice(0, -1)} id`] = {
+      keys: ['c'],
+      callback: () => { this.emit('key', 'c') }
     }
 
     const logCommands = {


### PR DESCRIPTION
# Summary
Copy id now changes to `copy container id` or `copy image id` depended on the view.

this resolve the discussion in the PR #154

## Proposed Changes

  - copy id changes depended on the view.

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [ ] Fixed issue #
- [ ] I added a picture of a cute animal cause it's fun
