### PR TITLE
fix: build image based on pinned deps in the project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN apk update && apk upgrade && apk add docker && rm -rf /var/apk/cache/*
 COPY . /app
 WORKDIR /app
 ENV NODE_ENV production
-RUN yarn install
+RUN yarn install --frozen-lockfile
 
 CMD ["node", "index.js"]


### PR DESCRIPTION
# Summary

Always install the docker image with pinned deps from the project rather than resolve in real-time

## Proposed Changes

  - Update the RUN directive to include the pinned-deps install phase of yarn

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [ ] Fixed issue #
- [ ] I added a picture of a cute animal cause it's fun
