### PR TITLE
feat: allow to pass arguments to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,7 @@ WORKDIR /app
 ENV NODE_ENV production
 RUN yarn install --frozen-lockfile
 
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
 CMD ["node", "index.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,4 @@ WORKDIR /app
 ENV NODE_ENV production
 RUN yarn install --frozen-lockfile
 
-COPY docker-entrypoint.sh /usr/local/bin/
-ENTRYPOINT ["docker-entrypoint.sh"]
-
-CMD ["node", "index.js"]
+ENTRYPOINT ["node", "index.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
+  set -- node index.js "$@"
+fi
+
+exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-set -e
-
-if [ "${1#-}" != "${1}" ] || [ -z "$(command -v "${1}")" ]; then
-  set -- node index.js "$@"
-fi
-
-exec "$@"


### PR DESCRIPTION
# Summary
Added the ability to pass dockly's arguments to [lirantal/dockly](https://hub.docker.com/r/lirantal/dockly) docker image without calling dockly explicitly

before
```bash
docker run -it --rm -v /var/run/docker.sock:/other/place/docker.sock lirantal/dockly node index -s /other/place/docker.sock 
```

now
```bash
docker run -it --rm -v /var/run/docker.sock:/other/place/docker.sock lirantal/dockly -s /other/place/docker.sock 
```


## Proposed Changes

  - Added the ability to pass dockly docker arguments without calling dockly explicitly
  
## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [ ] Fixed issue #
- [ ] I added a picture of a cute animal cause it's fun
