### PR TITLE
Fix/image view crash on enter

### DIFF
--- a/src/widgetsTemplates/list.widget.template.js
+++ b/src/widgetsTemplates/list.widget.template.js
@@ -122,10 +122,6 @@ class myWidget extends baseWidget(EventEmitter) {
     throw new Error('method getLabel not implemented')
   }
 
-  getLog () {
-    throw new Error('method getLog not implemented')
-  }
-
   getListItems (cb) {
     throw new Error('method getListItems not implemented')
   }

--- a/src/widgetsTemplates/list.widget.template.js
+++ b/src/widgetsTemplates/list.widget.template.js
@@ -29,14 +29,14 @@ class myWidget extends baseWidget(EventEmitter) {
         return null
       }
 
-      // clear log box of previous logs
-      this.clearItemLogs()
-
       // get logs for the items
       this.getItemLogs(itemId, (err, stream) => {
         if (err) {
           return null
         }
+
+        // clear log box of previous logs
+        this.clearItemLogs()
 
         let str
         if (stream && stream.pipe) {
@@ -120,6 +120,10 @@ class myWidget extends baseWidget(EventEmitter) {
 
   getLabel () {
     throw new Error('method getLabel not implemented')
+  }
+
+  getLog () {
+    throw new Error('method getLog not implemented')
   }
 
   getListItems (cb) {

--- a/widgets/images/imageList.widget.js
+++ b/widgets/images/imageList.widget.js
@@ -111,6 +111,10 @@ class myWidget extends ListWidget {
   getSelectedImage () {
     return this.widget.getItem(this.widget.selected).getContent().toString().trim().split(' ').shift()
   }
+
+  getItemLogs (itemId, cb) {
+    cb(new Error('image view don\'t have log widget'))
+  }
 }
 
 module.exports = myWidget


### PR DESCRIPTION
# Summary
Fixed image view crash on select

## Proposed Changes

  - Impelnated `getItemLogs` in image list.

  - move `clearItemLogs` after the check for errors in `getItemLogs`

  -

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [x] Fixed issue #173 
- [ ] I added a picture of a cute animal cause it's fun
