### PR TITLE
fix: dockly crash when copy to Clipboard fails

### DIFF
--- a/hooks/containers.hook.js
+++ b/hooks/containers.hook.js
@@ -1,10 +1,8 @@
 'use strict'
 
-const EventEmitter = require('events')
-const baseWidget = require('../src/baseWidget')
-const clipboardy = require('clipboardy')
+const baseHook = require('../src/widgetsTemplates/base.hook.template')
 
-class hook extends baseWidget(EventEmitter) {
+class hook extends baseHook {
   init () {
     // on startup we first emit data from the docker server
     this.getFreshData((err, data) => {
@@ -45,7 +43,7 @@ class hook extends baseWidget(EventEmitter) {
       }
 
       if (keyString === 'c') {
-        this.copyContainerIdToClipboard()
+        this.copyItemIdToClipboard()
       }
     })
 
@@ -167,20 +165,12 @@ class hook extends baseWidget(EventEmitter) {
     }
   }
 
-  copyContainerIdToClipboard () {
-    if (this.widgetsRepo && this.widgetsRepo.has('containerList')) {
-      const containerId = this.widgetsRepo.get('containerList').getSelectedContainer()
-      if (containerId) {
-        clipboardy.writeSync(containerId)
-
-        const actionStatus = this.widgetsRepo.get('actionStatus')
-        const message = `Container Id ${containerId} was copied to the clipboard`
-
-        actionStatus.emit('message', {
-          message: message
-        })
-      }
+  getSelectedItem() {
+    if (!this.widgetsRepo.has('containerList')) {
+      return null
     }
+
+    return this.widgetsRepo.get('containerList').getSelectedContainer()
   }
 }
 

--- a/hooks/containers.hook.js
+++ b/hooks/containers.hook.js
@@ -165,7 +165,7 @@ class hook extends baseHook {
     }
   }
 
-  getSelectedItem() {
+  getSelectedItem () {
     if (!this.widgetsRepo.has('containerList')) {
       return null
     }

--- a/hooks/images.hook.js
+++ b/hooks/images.hook.js
@@ -1,10 +1,8 @@
 'use strict'
 
-const EventEmitter = require('events')
-const baseWidget = require('../src/baseWidget')
-const clipboardy = require('clipboardy')
+const baseHook = require('../src/widgetsTemplates/base.hook.template')
 
-class hook extends baseWidget(EventEmitter) {
+class hook extends baseHook {
   init () {
     if (!this.widgetsRepo.has('toolbar')) {
       return null
@@ -21,25 +19,17 @@ class hook extends baseWidget(EventEmitter) {
       }
 
       if (keyString === 'c') {
-        this.copyImageIdToClipboard()
+        this.copyItemIdToClipboard()
       }
     })
   }
 
-  copyImageIdToClipboard () {
-    if (this.widgetsRepo && this.widgetsRepo.has('imageList')) {
-      const imageId = this.widgetsRepo.get('imageList').getSelectedImage()
-      if (imageId) {
-        clipboardy.writeSync(imageId)
-
-        const actionStatus = this.widgetsRepo.get('actionStatus')
-        const message = `Image Id ${imageId} was copied to the clipboard`
-
-        actionStatus.emit('message', {
-          message: message
-        })
-      }
+  getSelectedItem() {
+    if (!this.widgetsRepo.has('imageList')) {
+      return null
     }
+
+    return this.widgetsRepo.get('imageList').getSelectedImage()
   }
 
   notifyOnImageUpdate () {

--- a/hooks/images.hook.js
+++ b/hooks/images.hook.js
@@ -24,7 +24,7 @@ class hook extends baseHook {
     })
   }
 
-  getSelectedItem() {
+  getSelectedItem () {
     if (!this.widgetsRepo.has('imageList')) {
       return null
     }

--- a/hooks/services.hook.js
+++ b/hooks/services.hook.js
@@ -83,7 +83,7 @@ class hook extends baseHook {
     })
   }
 
-  getSelectedItem() {
+  getSelectedItem () {
     if (!this.widgetsRepo.has('servicesList')) {
       return null
     }

--- a/hooks/services.hook.js
+++ b/hooks/services.hook.js
@@ -1,10 +1,8 @@
 'use strict'
 
-const EventEmitter = require('events')
-const baseWidget = require('../src/baseWidget')
-const clipboardy = require('clipboardy')
+const baseHook = require('../src/widgetsTemplates/base.hook.template')
 
-class hook extends baseWidget(EventEmitter) {
+class hook extends baseHook {
   init () {
     // on startup we first emit data from the docker server
     this.getFreshData((err, data) => {
@@ -36,7 +34,7 @@ class hook extends baseWidget(EventEmitter) {
       }
 
       if (keyString === 'c') {
-        this.copyServiceIdToClipboard()
+        this.copyItemIdToClipboard()
       }
     })
 
@@ -85,20 +83,12 @@ class hook extends baseWidget(EventEmitter) {
     })
   }
 
-  copyServiceIdToClipboard () {
-    if (this.widgetsRepo && this.widgetsRepo.has('servicesList')) {
-      const serviceId = this.widgetsRepo.get('servicesList').getSelectedService()
-      if (serviceId) {
-        clipboardy.writeSync(serviceId)
-
-        const actionStatus = this.widgetsRepo.get('actionStatus')
-        const message = `Service Id ${serviceId} was copied to the clipboard`
-
-        actionStatus.emit('message', {
-          message: message
-        })
-      }
+  getSelectedItem() {
+    if (!this.widgetsRepo.has('servicesList')) {
+      return null
     }
+
+    return this.widgetsRepo.get('servicesList').getSelectedService()
   }
 }
 

--- a/src/widgetsTemplates/base.hook.template.js
+++ b/src/widgetsTemplates/base.hook.template.js
@@ -4,7 +4,6 @@ const EventEmitter = require('events')
 const clipboardy = require('clipboardy')
 
 class myWidget extends baseWidget(EventEmitter) {
-
   copyItemIdToClipboard () {
     const itemId = this.getSelectedItem()
     if (!itemId) {
@@ -20,7 +19,7 @@ class myWidget extends baseWidget(EventEmitter) {
       message = error
     } finally {
       const actionStatus = this.widgetsRepo.get('actionStatus')
-      
+
       actionStatus.emit('message', {
         message: message
       })

--- a/src/widgetsTemplates/base.hook.template.js
+++ b/src/widgetsTemplates/base.hook.template.js
@@ -1,0 +1,35 @@
+
+const baseWidget = require('../baseWidget')
+const EventEmitter = require('events')
+const clipboardy = require('clipboardy')
+
+class myWidget extends baseWidget(EventEmitter) {
+
+  copyItemIdToClipboard () {
+    const itemId = this.getSelectedItem()
+    if (!itemId) {
+      return
+    }
+
+    let message
+    try {
+      clipboardy.writeSync(itemId)
+
+      message = `Container Id ${itemId} was copied to the clipboard`
+    } catch (error) {
+      message = error
+    } finally {
+      const actionStatus = this.widgetsRepo.get('actionStatus')
+      
+      actionStatus.emit('message', {
+        message: message
+      })
+    }
+  }
+
+  getSelectedItem () {
+    throw new Error('method getSelectedItem not implemented')
+  }
+}
+
+module.exports = myWidget


### PR DESCRIPTION
# Summary
surrounded the `clipboardy.writeSync` function with try-catch
but instead of replicating the code on each hook, I created a `hook.template` class that contains the functionality 

## Proposed Changes

  - fixed dockly crash when clipboardy fails

  - added `hook.template` class


## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [x] Fixed issue #175 
- [ ] I added a picture of a cute animal cause it's fun
