### PR TITLE
fix: strip crlf to ensure it doesn't break the table layout

### DIFF
--- a/widgets/containers/containerList.widget.js
+++ b/widgets/containers/containerList.widget.js
@@ -64,7 +64,8 @@ class myWidget extends ListWidget {
           container.Id.substring(0, 5),
           container.Names[0].substring(0, 40),
           container.Image.substring(0, 35),
-          container.Command.substring(0, 30),
+          // remove any new lines or carriage return line feed from the string in container.Command
+          container.Command.substring(0, 30).replace(/(\r\n|\n|\r)/gm, ''),
           container.State,
           container.Status
         ]


### PR DESCRIPTION
# Summary
Fixes #205 which breaks the table layout if the docker command has CRLF related control characters in it
