### PR TITLE
feat: apply full-depth object information printing + colorize output

### DIFF
--- a/src/widgetsTemplates/info.widget.template.js
+++ b/src/widgetsTemplates/info.widget.template.js
@@ -50,7 +50,7 @@ class myWidget extends baseWidget() {
           // then show the information on the item
           this.getItemById(itemId, (err, data) => {
             if (!err) {
-              this.update(util.inspect(data))
+              this.update(util.inspect(data, { depth: null, colors: true }))
               this.screen.render()
             }
           })


### PR DESCRIPTION
Fixes #221 

This PR:
1. Fixes the object depth not being recursive when printing container info
2. Colorizes it

Example:
![image](https://user-images.githubusercontent.com/316371/216186611-d68b330d-3409-473d-a7aa-8b31764c6017.png)
