### PR TITLE
fix: increase limit on event listeners warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 'use strict'
 
+const { EventEmitter } = require('events')
+EventEmitter.defaultMaxListeners = 50
+
 /**
  * Project dependencies
  */


### PR DESCRIPTION
# Summary

Fixes #249 

## Proposed Changes

The toolbar widget (`toolbar.on()`) registers 11 event listeneres which triggers a Node.js memory leak warning:

```sh
erik@WS-91019:~$ dockly
(node:15356) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 key listeners added to [myWidget]. Use emitter.setMaxListeners() to increase limit
(Use node --trace-warnings ... to show where the warning was created)
```

There is no actual memory leak however, as it registers exactly 11 key presses for the toolbar.
This PR increases the limit to prevent the internal Node.js warning.

## Checklist

- [ ] I added tests
- [ ] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [x] Fixed issue #249
- [ ] I added a picture of a cute animal cause it's fun
