### PR TITLE
fix: missing name of the Docker image, for locally created images

### DIFF
--- a/widgets/images/imageList.widget.js
+++ b/widgets/images/imageList.widget.js
@@ -49,7 +49,7 @@ class myWidget extends ListWidget {
 
         imageList.push([
           image.Id.substring(7, 12),
-          (image.RepoDigests && image.RepoDigests.length) ? image.RepoDigests[0].split('@')[0] : getTag(image[2], 0),
+          (image.RepoDigests && image.RepoDigests.length) ? image.RepoDigests[0].split('@')[0] : getTag(image['RepoTags'], 0),
           getTag(image.RepoTags, 1),
           this.timeDifference(image.Created),
           this.formatBytes(image.Size)


### PR DESCRIPTION
# Summary
When Docker images are created locally, they do not have a digest. The name of the image then should be determined from the tag, but this accesses a non-existent value. Therefore no name is displayed:

![missing_image_name](https://github.com/lirantal/dockly/assets/76621625/5f438ae9-b7da-410f-ae28-9c1e51e10d48)

This pull request fixes this problem and the Docker image name is correctly displayed on the overview.

![fixed_image_name](https://github.com/lirantal/dockly/assets/76621625/f5e0988f-141e-4489-947f-982eb1b09c9e)

## Proposed Changes

- **imageList.widget.js 52**: `image[2]` evaluates undefined and therefore should be changed to `image['RepoTags']`


## Checklist

- [ ] I added tests
- [x] I updated the README if necessary
- [ ] This PR introduces a breaking change
- [ ] Fixed issue #
- [ ] I added a picture of a cute animal cause it's fun
